### PR TITLE
Betterbuild

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,10 @@ jobs:
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: $VERSION
 
         with:
-          tag_name: v${{ steps.build.outputs.version }}
+          tag_name: v${{ env.VERSION }}
           release_name: Release v$VERSION
           body: |
             ${{ steps.build.outputs.description }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: $(VERSION)
+          VERSION: ${{ steps.build.outputs.VERSION }}
 
         with:
           tag_name: v${{ env.VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - experimental-betterbuild
-    paths:
-      - '**src/*'
 
 jobs:
   build-linux:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: $(VERSION)
+          VERSION: ${{ steps.build.outputs.VERSION }}
 
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.build.outputs.VERSION }}
 
         with:
           tag_name: v${{ env.VERSION }}
@@ -37,7 +36,6 @@ jobs:
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.build.outputs.VERSION }}
 
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,7 @@ jobs:
         id: build
         run: |
           source build.sh
-          echo "::set-output name=version::${VERSION}"
-          echo "::set-output name=description::${DESCRIPTION}"
+          cat release_info.txt >> $GITHUB_ENV
 
       - name: Create GitHub Release with binary attachments
         id: create_release
@@ -29,7 +28,7 @@ jobs:
 
         with:
           tag_name: v${{ steps.build.outputs.version }}
-          release_name: Release v${{ steps.build.outputs.version }}
+          release_name: Release v$VERSION
           body: |
             ${{ steps.build.outputs.description }}
 
@@ -40,6 +39,6 @@ jobs:
 
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/snowfox-linux-${{ steps.build.outputs.version }}
-          asset_name: snowfox-linux-${{ steps.build.outputs.version }}
+          asset_path: ./build/snowfox-linux-$VERSION
+          asset_name: snowfox-linux-$VERSION
           asset_content_type: application/octet-stream

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,10 @@ jobs:
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: $VERSION
 
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/snowfox-linux-$VERSION
-          asset_name: snowfox-linux-$VERSION
+          asset_path: ./build/snowfox-linux-${{ env.VERSION }}
+          asset_name: snowfox-linux-${{ env.VERSION }}
           asset_content_type: application/octet-stream

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - experimental-betterbuild
     paths:
       - '**src/*'
 
@@ -15,41 +16,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Clean previous build artifacts (Linux)
+      - name: Build SnowFox versions
+        id: build
         run: |
-          rm -rf build
-          mkdir build
+          source build.sh
+          echo "::set-output name=version::${VERSION}"
+          echo "::set-output name=description::${DESCRIPTION}"
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y g++ make cmake
-
-      - name: Read version and description from file
-        id: read_release_info
-        run: |
-          RELEASE_INFO=$(cat release_info.txt)
-          echo "::set-output name=version::$(echo "$RELEASE_INFO" | grep '^VERSION=' | sed 's/VERSION=//')"
-          echo "::set-output name=description::$(echo "$RELEASE_INFO" | grep '^DESCRIPTION=' | sed 's/DESCRIPTION=//')"
-
-      - name: Build snowfox for Linux
-        run: |
-          cd build
-          cmake ../src -DCMAKE_CXX_STANDARD=20
-          make snowfox
-          mv snowfox snowfox-linux-${{ steps.read_release_info.outputs.version }}
-
-      - name: Create GitHub Release with binary attachment
+      - name: Create GitHub Release with binary attachments
         id: create_release
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         with:
-          tag_name: v${{ steps.read_release_info.outputs.version }}
-          release_name: Release v${{ steps.read_release_info.outputs.version }}
+          tag_name: v${{ steps.build.outputs.version }}
+          release_name: Release v${{ steps.build.outputs.version }}
           body: |
-            ${{ steps.read_release_info.outputs.description }}
+            ${{ steps.build.outputs.description }}
 
       - name: Upload snowfox binary to release
         uses: actions/upload-release-asset@v1
@@ -58,6 +42,6 @@ jobs:
 
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/snowfox-linux-${{ steps.read_release_info.outputs.version }}
-          asset_name: snowfox-linux-${{ steps.read_release_info.outputs.version }}
+          asset_path: ./build/snowfox-linux-${{ steps.build.outputs.version }}
+          asset_name: snowfox-linux-${{ steps.build.outputs.version }}
           asset_content_type: application/octet-stream

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,11 @@ jobs:
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: $VERSION
+          VERSION: $(VERSION)
 
         with:
           tag_name: v${{ env.VERSION }}
-          release_name: Release v$VERSION
+          release_name: Release v${{ env.VERSION }}
           body: |
             ${{ steps.build.outputs.description }}
 
@@ -37,7 +37,7 @@ jobs:
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: $VERSION
+          VERSION: $(VERSION)
 
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - experimental-betterbuild
+    paths:
+      - 'release.env'
 
 jobs:
   build-linux:
@@ -18,7 +20,7 @@ jobs:
         id: build
         run: |
           source build.sh
-          cat release_info.txt >> $GITHUB_ENV
+          cat release.env >> $GITHUB_ENV
 
       - name: Create GitHub Release with binary attachments
         id: create_release
@@ -30,7 +32,7 @@ jobs:
           tag_name: v${{ env.VERSION }}
           release_name: Release v${{ env.VERSION }}
           body: |
-            ${{ steps.build.outputs.description }}
+            ${{ env.DESCRIPTION }}
 
       - name: Upload snowfox binary to release
         uses: actions/upload-release-asset@v1

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-eval $(grep -v -e '^#' release_info.txt | xargs -I {} echo export "'{}'")
+eval $(grep -v -e '^#' release.env | xargs -I {} echo export "'{}'")
 
 mkdir temp
 mkdir build 2>/dev/null

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-RELEASE_INFO=$(cat release_info.txt)
-VERSION=$(echo "$RELEASE_INFO" | grep '^VERSION=' | sed 's/VERSION=//')
+eval $(grep -v -e '^#' release_info.txt | xargs -I {} echo export "'{}'")
 
 mkdir temp
 mkdir build 2>/dev/null

--- a/release.env
+++ b/release.env
@@ -1,0 +1,2 @@
+VERSION=0.0.2
+DESCRIPTION=Improved the build system

--- a/release.env
+++ b/release.env
@@ -1,2 +1,2 @@
 VERSION=0.0.2
-DESCRIPTION=Improved the build system
+DESCRIPTION= - Improved the build system

--- a/release_info.txt
+++ b/release_info.txt
@@ -1,2 +1,2 @@
-VERSION=0.0.1
+VERSION=0.0.2
 DESCRIPTION= - Now we have ASCII art and daily messages :)

--- a/release_info.txt
+++ b/release_info.txt
@@ -1,2 +1,0 @@
-VERSION=0.0.2
-DESCRIPTION= - Now we have ASCII art and daily messages :)


### PR DESCRIPTION
Originally an experimental branch because it required several pushes to test, so it wouldn't be nice for an alpha

This branch changes how the build work, now there is a release.env file, which is responsible for delegating variables to be used both by git and by the build file

Pushes made to the release file trigger the workflow, so it will only happen when you explicitly change the version number and/or its description instead of every time a push is made to the src folder

The build.yml file gets its variables from the env file instead of using the now deprecated set output function, so there are no more warnings regarding this